### PR TITLE
field_filter causes validator error, use number_filter

### DIFF
--- a/redshift_query_inspection.dashboard.lookml
+++ b/redshift_query_inspection.dashboard.lookml
@@ -6,7 +6,7 @@
 
   filters:
   - name: query
-    type: field_filter
+    type: number_filter
     explore: redshift_queries
     field: redshift_queries.query
     default: 0


### PR DESCRIPTION
I tried adding the block to a Looker project (Looker 4.22.23, new LookML project) and the validator threw an error saying redshift_queries.query was inaccessible.

Changing the filter definition to number_filter solved this.