### PR TITLE
Update svv_table_info.pct_used to use correct type

### DIFF
--- a/redshift_views.view.lkml
+++ b/redshift_views.view.lkml
@@ -542,7 +542,7 @@ view: redshift_tables {
         "sortkey1_enc"::varchar,
         "sortkey_num"::int,
         "size"::bigint,
-        "pct_used"::numeric,
+        "pct_used"::numeric(10,4),
         "unsorted"::numeric,
         "stats_off"::numeric,
         "tbl_rows"::bigint,
@@ -712,6 +712,11 @@ view: redshift_tables {
       description: "Size of the table(s), in 1 MB data blocks"
       type: sum
       sql: ${size} ;;
+    }
+    measure: total_percent_used {
+      description: "Total percent used by the tables"
+      type: sum
+      sql: ${pct_used} ;;
     }
 
   }


### PR DESCRIPTION
svv_table_info.pct_used is using the incorrect type based on https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_TABLE_INFO.html , which results underestimating the amount of space used on the cluster. (pct_used is floored.)